### PR TITLE
Add a script to run the toolbox in a docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 RBM Toolbox for Torch
 ===============
 
-RBM toolbox is a Torch7 toolbox for online training of RBM's. A MATLAB version exists at 
+RBM toolbox is a Torch7 toolbox for online training of RBM's. A MATLAB version exists at
 [LINK](https://github.com/skaae/rbm_toolbox).
 
 The following is supported:
@@ -13,23 +13,38 @@ The following is supported:
  * CD - k (contrastive divergence k) [5]
  * PCD (persistent contrastive divergence) [6]
  * RBM Classification support [2,7]
- * Regularization: L1, L2, sparsity, early-stopping, dropout [1], momentum [3] 
+ * Regularization: L1, L2, sparsity, early-stopping, dropout [1], momentum [3]
 
 # Installation
 
+## Local installation
  1. Install torch7: Follow [these](https://github.com/torch/torch7/wiki/Cheatsheet#installing-and-running-torch) instructions
  2. download this repository: `git clone https://github.com/skaae/rbm_toolbox_lua.git`
- 4. To run the examples install wget with homebrew
- 3. Run example rbms with examples/runrbm.lua 
+ 4. To run the examples install wget/curl with homebrew
+ 3. Run example rbms with examples/runrbm.lua
+
+## Using it through Docker
+
+It is possible to run the entire toolbox (and all its dependencies) in a docker
+container instead of installing torch locally. Once the repository has been
+pulled, a script is available to launch a docker container and map the local
+repository directory to a volume in the container.
+
+1. download this repository: `git clone https://github.com/skaae/rbm_toolbox_lua.git`
+2. run the shell script ```run_docker.sh```
+
+In the container:
+
+3. run example rbms with examples/runrbm.lua
 
 # Examples
 Run from /example folder
 
 
   1) th runrbm.lua -eta 0.05 -alpha 0 -nhidden 500 -folder test_discriminative
-  
+
   2) th runrbm.lua -eta 0.05 -alpha 0 -nhidden 500 -folder test_discriminative_dropout -dropout 0.5
-  
+
    3) th runrb,.lua -eta 0.05 -alpha 1 -nhidden 500 -folder test_generative_pcd -traintype PCD
    4) th runrbm.lua -eta 0.05 -alpha 0.01 -nhidden 1500 -folder test_hybrid
 
@@ -55,7 +70,7 @@ require(codeFolder..'dataset-from-tensor')
 require 'paths'
 geometry = {1,100}   -- dimensions of your training data
 nclasses = 3
-nSamples = 5 
+nSamples = 5
 trainTensor = torch.rand(nSamples,geometry[1],geometry[2])
 trainLabels = torch.Tensor({1,2,3,1,2})
 classes = {'ClassA','ClassB','ClassC'}
@@ -70,24 +85,24 @@ print(trainData:classnames())
 ```
 # TODO
 
- 1. DO DROPOUT DISCRIMINATIVE WITH SPARSITY?   
- 2. Use momentum to smooth gradients? + Decrease learning rate    
- 3. Generative training example + samples drawn from model   
+ 1. DO DROPOUT DISCRIMINATIVE WITH SPARSITY?
+ 2. Use momentum to smooth gradients? + Decrease learning rate
+ 3. Generative training example + samples drawn from model
  4. Hybrid training exampe
  5. Semisupervised example
  6. Implement stacking of RBM's
 
 # References
 
-[1] Srivastava Nitish, G. Hinton, A. Krizhevsky, I. Sutskever, and R. R. Salakhutdinov, “Dropout: A Simple Way to Prevent Neural Networks from Overfitting,” J. Mach. Learn. Res., vol. 5(Jun), no. 2, p. 1929−1958, 2014.    
-[2] H. Larochelle and Y. Bengio, “Classification using discriminative restricted Boltzmann machines,” in Proceedings of the 25th international conference on Machine learning. ACM,, 2008.     
-[3] G. Hinton, “A practical guide to training restricted Boltzmann machines,” Momentum, vol. 9, no. 1, p. 926, 2010.    
-[4] G. Hinton, N. Srivastava, A. Krizhevsky, I. Sutskever, and R. R. Salakhutdinov, “Improving neural networks by preventing co-adaptation of feature detectors,” arXiv Prepr., vol. 1207.0580, no. Hinton, Geoffrey E., et al. "Improving neural networks by preventing co-adaptation of feature detectors." arXiv preprint arXiv:1207.0580 (2012)., Jul. 2012.    
-[5] G. Hinton, “Training products of experts by minimizing contrastive divergence,” Neural Comput., vol. 14, no. 8, pp. 1771–1800, 2002.     
-[6] T. Tieleman, “Training restricted Boltzmann machines using approximations to the likelihood gradient,” in Proceedings of the 25th international conference on Machine learning. ACM, 2008.    
-[7] H. Larochelle, M. Mandel, R. Pascanu, and Y. Bengio, “Learning algorithms for the classification restricted boltzmann machine,” J. Mach. Learn. Res., vol. 13, no. 1, pp. 643–669, 2012.    
-[8] R. Salakhutdinov and I. Murray, “On the quantitative analysis of deep belief networks,” in Proceedings of the 25th international conference on Machine learning. ACM,, 2008.    
-[9] Y. Tang and I. Sutskever, “Data normalization in the learning of restricted Boltzmann machines,” Dep. Comput. Sci. Toronto Univ., vol. UTML-TR-11, 2011.     
-[10] L. Wan, M. Zeiler, S. Zhang, Y. Le Cun, and R. Fergus, “Regularization of Neural Networks using DropConnect,” in Proceedings of The 30th International Conference on Machine Learning, 2013, pp. 1058–1066. 
+[1] Srivastava Nitish, G. Hinton, A. Krizhevsky, I. Sutskever, and R. R. Salakhutdinov, “Dropout: A Simple Way to Prevent Neural Networks from Overfitting,” J. Mach. Learn. Res., vol. 5(Jun), no. 2, p. 1929−1958, 2014.
+[2] H. Larochelle and Y. Bengio, “Classification using discriminative restricted Boltzmann machines,” in Proceedings of the 25th international conference on Machine learning. ACM,, 2008.
+[3] G. Hinton, “A practical guide to training restricted Boltzmann machines,” Momentum, vol. 9, no. 1, p. 926, 2010.
+[4] G. Hinton, N. Srivastava, A. Krizhevsky, I. Sutskever, and R. R. Salakhutdinov, “Improving neural networks by preventing co-adaptation of feature detectors,” arXiv Prepr., vol. 1207.0580, no. Hinton, Geoffrey E., et al. "Improving neural networks by preventing co-adaptation of feature detectors." arXiv preprint arXiv:1207.0580 (2012)., Jul. 2012.
+[5] G. Hinton, “Training products of experts by minimizing contrastive divergence,” Neural Comput., vol. 14, no. 8, pp. 1771–1800, 2002.
+[6] T. Tieleman, “Training restricted Boltzmann machines using approximations to the likelihood gradient,” in Proceedings of the 25th international conference on Machine learning. ACM, 2008.
+[7] H. Larochelle, M. Mandel, R. Pascanu, and Y. Bengio, “Learning algorithms for the classification restricted boltzmann machine,” J. Mach. Learn. Res., vol. 13, no. 1, pp. 643–669, 2012.
+[8] R. Salakhutdinov and I. Murray, “On the quantitative analysis of deep belief networks,” in Proceedings of the 25th international conference on Machine learning. ACM,, 2008.
+[9] Y. Tang and I. Sutskever, “Data normalization in the learning of restricted Boltzmann machines,” Dep. Comput. Sci. Toronto Univ., vol. UTML-TR-11, 2011.
+[10] L. Wan, M. Zeiler, S. Zhang, Y. Le Cun, and R. Fergus, “Regularization of Neural Networks using DropConnect,” in Proceedings of The 30th International Conference on Machine Learning, 2013, pp. 1058–1066.
 
 Copyright (c) 2014, Søren Kaae Sønderby (skaaesonderby@gmail.com) All rights reserved.

--- a/code/dataset-mnist.lua
+++ b/code/dataset-mnist.lua
@@ -8,11 +8,23 @@ mnist.path_dataset = 'mnist-th7'
 mnist.path_trainset = paths.concat(mnist.path_dataset, 'train.th7')
 mnist.path_testset = paths.concat(mnist.path_dataset, 'test.th7')
 
+function get_download_executable()
+   -- check to see if wget is available, and use curl if this is not the case.
+   local exe = 'wget '
+   local wget_found = os.execute('wget --help')
+   if not wget_found then
+      exe = 'curl -OL '
+   end
+
+   return exe
+end
+
 function mnist.download()
    if not paths.filep(mnist.path_trainset) or not paths.filep(mnist.path_testset) then
       local remote = mnist.path_remote
       local tar = paths.basename(remote)
-      os.execute('wget ' .. remote .. '; ' .. 'tar xvf ' .. tar .. '; rm ' .. tar)
+      local ulr_getter = get_download_executable()
+      os.execute(ulr_getter .. remote .. '; ' .. 'tar xvf ' .. tar .. '; rm ' .. tar)
    end
 end
 
@@ -119,7 +131,7 @@ end
 function mnist.loadConvDataset(fileName, maxLoad, geometry,trainOrVal,boost,name)
    local dataset = mnist.loadFlatDataset(fileName, maxLoad,trainOrVal)
    local cdataset = {}
-   
+
    function cdataset:normalize(m,s)
       return dataset:normalize(m,s)
    end
@@ -147,12 +159,12 @@ function mnist.loadConvDataset(fileName, maxLoad, geometry,trainOrVal,boost,name
    local currentPerm   = torch.randperm(nSamples)
    local skipped = 0
 
-   --iterator over dataset 
+   --iterator over dataset
    function cdataset:nextboost()
       if boost == 'none' then
             print('boost is not enabled for this dataset')
             error()
-      end 
+      end
             --if boost == 'diff' then
       -- print('add some function that samples based on yprop')
       -- print('+add function to get number of indeces check')
@@ -168,7 +180,7 @@ function mnist.loadConvDataset(fileName, maxLoad, geometry,trainOrVal,boost,name
             end
             --print(ex[2])
             local _,idx = torch.max(sample[2],1)
-            
+
             local pred_prob = myprob[{currentSample-1,idx[1]}]
             --print(currentSample,correct_prob)
             local sampling_prob = 1-pred_prob
@@ -195,9 +207,9 @@ function mnist.loadConvDataset(fileName, maxLoad, geometry,trainOrVal,boost,name
          currentPerm   = torch.randperm(nSamples)
 
       end
-      
+
       currentSample = currentSample + 1
-      return self[ currentPerm[currentSample-1] ]      
+      return self[ currentPerm[currentSample-1] ]
    end
 
    function cdataset:getcurrentsample()

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
-IMAGE_NAME=itorch
+# Use the following image name (this should be available on DockerHub)
+IMAGE_NAME="kkoba84/itorch-docker"
 
-docker run -d -p 9999:9999 -v `pwd`:/root/mount -it $IMAGE_NAME /root/torch/install/bin/itorch notebook --profile=itorch_svr
+# Pull the required docker image from DockerHub.
+docker pull $IMAGE_NAME
+
+# Use the following path in the container.
+CONTAINER_PATH=/root/workspace/rbm_toolbox_lua
+
+# Launch the container.
+docker run -w "$CONTAINER_PATH" -p 9999:9999 -v `pwd`:$CONTAINER_PATH -it $IMAGE_NAME bash
+
+# The following would start the itorch server and connect to the container.
+# It is disabled by default.
+if false
+then
+	# Start the container with with the iTorch server
+	docker run -w "$CONTAINER_PATH" -d -p 9999:9999 -v `pwd`:$CONTAINER_PATH -it $IMAGE_NAME /root/torch/install/bin/itorch notebook --profile=itorch_svr
+	# Get the container ID from docker ps
+	CONAINER_ID=`docker ps -l -n=1 -a | grep -oE "^\S+\s\s"`
+	# Connect to the running container
+	docker exec -ti $CONAINER_ID "bash"
+fi
 


### PR DESCRIPTION
I have updated the shell script to use the Docker image from https://github.com/kkoba84/itorch-docker as a base and launch an interactive shell for using the RBM toolbox. This includes an updated section in the README.

As the docker image did not contain `wget`, I also made it possible to use `curl` (which is included in the image) to download the MNIST examples.
